### PR TITLE
Add support for OVMF hashes

### DIFF
--- a/sevsnpmeasure/gctx.py
+++ b/sevsnpmeasure/gctx.py
@@ -39,8 +39,8 @@ class GCTX(object):
     # 51 are cleared.
     VMSA_GPA = 0xFFFFFFFFF000
 
-    def __init__(self):
-        self._ld = ZEROS
+    def __init__(self, seed: bytes = ZEROS):
+        self._ld = seed
 
     def ld(self) -> bytes:
         return self._ld

--- a/tests/test_guest.py
+++ b/tests/test_guest.py
@@ -11,6 +11,46 @@ from sevsnpmeasure.sev_mode import SevMode
 
 class TestGuest(unittest.TestCase):
 
+    # Test of we can generate a good OVMF hash
+    def test_snp_ovmf_hash_gen(self):
+        ovmf_hash = 'cab7e085874b3acfdbe2d96dcaa3125111f00c35c6fc9708464c2ae74bfdb048a198cb9a9ccae0b3e5e1a33f5f249819'
+        ld = guest.calc_launch_digest(
+                SevMode.SEV_SNP,
+                1,
+                vcpu_types.CPU_SIGS["EPYC-v4"],
+                "tests/fixtures/ovmf_suffix.bin",
+                "/dev/null",
+                "/dev/null",
+                "",
+                snp_ovmf_hash_str = ovmf_hash)
+        self.assertEqual(
+                ld.hex(),
+                '6a23d4774a60f6238506b531e0cb60a698a198db100476f6'
+                'fadb724f60c144bed9c71a3903b9ca425ff82b376c381b33')
+
+    # Test of we can a full LD from the OVMF hash
+    def test_snp_ovmf_hash_full(self):
+        ovmf_hash = guest.calc_snp_ovmf_hash("tests/fixtures/ovmf_suffix.bin").hex()
+        self.assertEqual(
+                ovmf_hash,
+                '4ef91bfd7241908300ac19305a694753cbc8db28104f356f'
+                'd7860cc7b4119db285ce80586c19bd358a731d5267cee60e')
+
+        ld = guest.calc_launch_digest(
+                SevMode.SEV_SNP,
+                1,
+                vcpu_types.CPU_SIGS["EPYC-v4"],
+                "tests/fixtures/ovmf_suffix.bin",
+                "/dev/null",
+                "/dev/null",
+                "",
+                snp_ovmf_hash_str = ovmf_hash)
+
+        self.assertEqual(
+                ld.hex(),
+                '38859e76ac5fa5009c8249eb2f44dafb33a2a1f41efd65ce'
+                'b13f042864abab87d018dc64da21628b320a98642f25ae6c')
+
     def test_snp(self):
         ld = guest.calc_launch_digest(
                 SevMode.SEV_SNP,


### PR DESCRIPTION
Some times we may not want to have to keep the full OVMF binary handy when we try to validate a measurement. Most of the data we extract out of the OVMF binary is static, except for its actual hashes.

So let's introduce a new mode that generates a precalculated launch digest that contains the SNP ld hash at the point where we fully ingested OVMF's contents:

    $ sev-snp-measure --mode ovmf-hash --ovmf OVMF.fd
    cab7e[...]

In addition, add a new optional parameter that a user can then use to consume the hash instead of recalculating it from their OVMF binary at hand:

    $ sev-snp-measure --mode snp --vcpus=1 --vcpu-type=EPYC-v4 \
                      --ovmf=OVMF.fd.old --ovmf-hash cab7e[...]
    d5269[...]

With this in place, users no longer need to copy full OVMF binaries around. Instead, for almost all SEV-SNP capable OVMF binaries in existence today, we can merely share their hash values and are still able to validate VM measurements.