### PR TITLE
vcpu_types: Add EPYC-Genoa vcpu signature

### DIFF
--- a/sevsnpmeasure/vcpu_types.py
+++ b/sevsnpmeasure/vcpu_types.py
@@ -39,4 +39,6 @@ CPU_SIGS = {
     'EPYC-Milan': cpu_sig(family=25, model=1, stepping=1),
     'EPYC-Milan-v1': cpu_sig(family=25, model=1, stepping=1),
     'EPYC-Milan-v2': cpu_sig(family=25, model=1, stepping=1),
+    'EPYC-Genoa': cpu_sig(family=25, model=17, stepping=0),
+    'EPYC-Genoa-v1': cpu_sig(family=25, model=17, stepping=0),
 }


### PR DESCRIPTION
According to the CPU definition in QEMU:

https://gitlab.com/qemu-project/qemu/-/blob/master/target/i386/cpu.c#L4548-4553