### PR TITLE
Verify --kernel is used when --initrd/--append are specified

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
   which is slightly different than the way QEMU measures the initial VM state
   (by [@agraf](https://github.com/agraf)).
 - Detect OVMF that doesn't support kernel hashes and exit with error.
+- Exit with error if `--initrd`/`--append` are used without `--kernel`.
 
 ## 0.0.5 - 2023-04-13
 

--- a/sevsnpmeasure/cli.py
+++ b/sevsnpmeasure/cli.py
@@ -76,6 +76,12 @@ def main() -> int:
         print(guest.calc_snp_ovmf_hash(args.ovmf).hex())
         return 0
 
+    if args.initrd and args.kernel is None:
+        parser.error("--kernel required when using --initrd")
+
+    if args.append and args.kernel is None:
+        parser.error("--kernel required when using --append")
+
     if args.mode != 'sev' and args.vcpus is None:
         parser.error(f"missing --vcpus N in guest mode '{args.mode}'")
 


### PR DESCRIPTION
(complete the suggestions from #19)

With this PR:

```
$ python ./sev-snp-measure.py --mode sev --ovmf OVMF.fd --initrd initrd.img
usage: sev-snp-measure [-h] [--version] [-v] --mode {sev,seves,snp,snp:ovmf-hash} [--vcpus N] [--vcpu-type CPUTYPE] [--vcpu-sig VALUE]
                       [--vcpu-family FAMILY] [--vcpu-model MODEL] [--vcpu-stepping STEPPING] [--vmm-type VMMTYPE] --ovmf PATH [--kernel PATH]
                       [--initrd PATH] [--append CMDLINE] [--output-format {hex,base64}] [--snp-ovmf-hash HASH]
sev-snp-measure: error: --kernel required when using --initrd
```